### PR TITLE
Test and publish a multi-release jar

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,3 +57,38 @@ jobs:
       if: matrix.java == 23
       run: |
         sbt core/doc
+
+  integration:
+    runs-on: ubuntu-latest
+    name: Multi-Release JAR Integration Test
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        java-version: |
+          21
+          22
+        distribution: 'temurin'
+        cache: 'sbt'
+    - name: Set up sbt
+      uses: sbt/setup-sbt@v1
+    - name: Run tests
+      run: |
+        # Build multi-release override classes on Java 22
+        PATH=$JAVA_HOME_22_X64/bin:$PATH JAVA_HOME=$JAVA_HOME_22_X64 sbt \
+          core/compile
+        cp -r core/target/classes override-core-j22
+        # Build jar on Java 21 with --enable-preview and include Java 22 overrides
+        PATH=$JAVA_HOME_21_X64/bin:$PATH JAVA_HOME=$JAVA_HOME_21_X64 JAVA_OPTS=--enable-preview \
+          OVERRIDE_CORE_J22=`realpath override-core-j22` sbt \
+          core/clean \
+          core/packageBin
+        # Run tests with multi-release jar
+        cp `realpath core/target/perfio-*.jar` override-test.jar
+        PATH=$JAVA_HOME_21_X64/bin:$PATH JAVA_HOME=$JAVA_HOME_21_X64 JAVA_OPTS=--enable-preview \
+          OVERRIDE_TEST_JAR=`realpath override-test.jar` sbt \
+          test/test
+        PATH=$JAVA_HOME_22_X64/bin:$PATH JAVA_HOME=$JAVA_HOME_22_X64 \
+          OVERRIDE_TEST_JAR=`realpath override-test.jar` sbt \
+          test/test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
       with:
         java-version: |
           21
+          22
           23
         distribution: 'temurin'
         cache: 'sbt'
@@ -42,9 +43,15 @@ jobs:
         SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
         SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
       run: |
-        # Publish binaries with Java 21 (because we can't use --enable-preview for 21 from 23)
-        PATH=$JAVA_HOME_21_X64/bin:$PATH JAVA_HOME=$JAVA_HOME_21_X64 JAVA_OPTS=--enable-preview sbt \
+        # Build multi-release override classes with Java 22
+        PATH=$JAVA_HOME_22_X64/bin:$PATH JAVA_HOME=$JAVA_HOME_22_X64 sbt \
+          core/compile
+        cp -r core/target/classes override-core-j22
+        # Publish binaries with Java 21 with --enable-preview and include Java 22 overrides
+        PATH=$JAVA_HOME_21_X64/bin:$PATH JAVA_HOME=$JAVA_HOME_21_X64 JAVA_OPTS=--enable-preview \
+          OVERRIDE_CORE_J22=`realpath override-core-j22` sbt \
           "set core/Compile/packageDoc/publishArtifact := false" \
+          core/clean \
           core/publishSigned
         ls -lR target/sonatype-staging
         # Publish javadoc with Java 23 (because we need Markdown support)


### PR DESCRIPTION
The previously published jars only worked on Java 21 because classes that need `--enable-preview` are not compatible between Java releases (even when the API is identical). We now still build the base contents of the jar on Java 21, but we add Java 22 overrides for all classes that have the preview flag set.